### PR TITLE
Fix bug in Auditable#last_change_of method

### DIFF
--- a/lib/auditable/auditing.rb
+++ b/lib/auditable/auditing.rb
@@ -85,12 +85,13 @@ module Auditable
     #
     # This method may be slow and inefficient on model with lots of audit objects.
     def last_change_of(attribute)
-      prev_audit = nil
+      index = audits.count
       audits.reverse_each do |audit|
+        index -= 1
         if audit.modifications[attribute].present?
+          prev_audit = audits[index-1] if index > 0
           return audit.diff(prev_audit)[attribute]
         end
-        prev_audit = audit
       end
       nil
     end

--- a/spec/lib/auditable_spec.rb
+++ b/spec/lib/auditable_spec.rb
@@ -162,8 +162,21 @@ describe Auditable do
     let(:some_survey) { Survey.create :title => "some survey" }
     it "should audit return last change of attribute even through last update not changes this attribute" do
       some_survey.update_attributes :title => "new title 1", :current_page => 1
-      some_survey.update_attributes :title => "new title 2"
+      some_survey.update_attributes :title => "new title 2", :current_page => 2
       some_survey.should respond_to :last_change_of
+      some_survey.last_change_of("current_page").should == [1, 2]
+    end
+
+    let(:some_survey) { Survey.create :title => "some survey" }
+    it "should audit return nil if no changes" do
+      some_survey.update_attributes :title => "new title 1"
+      some_survey.update_attributes :title => "new title 2"
+      some_survey.last_change_of("current_page").should == nil
+    end
+
+    let(:some_survey) { Survey.create :title => "some survey" }
+    it "should audit return last modifications even if only one audit object present" do
+      some_survey.update_attributes :title => "new title 1", :current_page => 1
       some_survey.last_change_of("current_page").should == [nil, 1]
     end
   end


### PR DESCRIPTION
I fix bug in the last_change_of method.
But I found another issue.

This tests are broken for me.
Is auditable stores only changed fields (or values from methods)?

``` ruby

    let(:some_survey) { Survey.create :title => "some survey" }
    it "should audit return correct changes" do
      some_survey.update_attributes :title => "new title 1", :current_page => 1
      some_survey.update_attributes :title => "new title 2", :current_page => 2
      some_survey.update_attributes :title => "new title 3"
      some_survey.update_attributes :title => "new title 4"
      some_survey.update_attributes :title => "new title 5"
      some_survey.audits.last.modifications.should == {"title"=>"new title 5"}
      some_survey.last_change_of("current_page").should == [1, 2]
    end
```
