### PR TITLE
add class_name option for method audit

### DIFF
--- a/lib/auditable.rb
+++ b/lib/auditable.rb
@@ -1,5 +1,6 @@
 require 'active_record'
 require 'active_support/concern'
+require 'active_support/core_ext/array/extract_options'
 
 require "auditable/version"
 require 'auditable/audit'

--- a/lib/auditable/auditing.rb
+++ b/lib/auditable/auditing.rb
@@ -22,12 +22,15 @@ module Auditable
       #   class Survey < ActiveRecord::Base
       #     audit :page_count, :question_ids
       #   end
-      def audit(*options)
-        has_many :audits, :class_name => "Auditable::Audit", :as => :auditable
+      def audit(*args)
+        options = args.extract_options!
+        options[:class_name] ||= "Auditable::Audit"
+        options[:as] = :auditable
+        has_many :audits, options
         after_create {|record| record.snap!(:action => "create")}
         after_update {|record| record.snap!(:action => "update")}
 
-        self.audited_attributes = Array.wrap options
+        self.audited_attributes = Array.wrap args
       end
     end
 

--- a/spec/lib/auditable_spec.rb
+++ b/spec/lib/auditable_spec.rb
@@ -11,6 +11,10 @@ describe Auditable do
   let(:user) { User.create :name => "test user" }
   let(:another_user) { User.create :name => "another user" }
 
+  it "should have a valid audit class name" do
+    survey.audits.first.should be_instance_of(MyAudit)
+  end
+
   it "should have a valid audit to start with" do
     survey.title.should == "test survey"
     survey.audited_changes.should == {"title" => [nil, "test survey"]}

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -1,11 +1,15 @@
 class Survey < ActiveRecord::Base
   attr_accessor :current_page
 
-  audit :title, :current_page
+  audit :title, :current_page, :class_name => "MyAudit"
 end
 
 class User < ActiveRecord::Base
   audit :name
+end
+
+class MyAudit < Auditable::Audit
+
 end
 
 # TODO add Question class to give examples on association stuff


### PR DESCRIPTION
I need to add a little business logic in my class. For this I need to override your class audit. In my model, I do so - audit: title,: current_page,: class_name => "MyAudit" and then I write my Myaudit class that inherits from your Audiable :: Audit and write in it my logic.
