### PR TITLE
add attr_accessible for Audit model

### DIFF
--- a/lib/auditable/audit.rb
+++ b/lib/auditable/audit.rb
@@ -4,6 +4,8 @@ module Auditable
     belongs_to :user, :polymorphic => true
     serialize :modifications
 
+    attr_accessible :action, :modifications
+
     # Diffing two audits' modifications
     #
     # Returns a hash containing arrays of the form


### PR DESCRIPTION
Add attr_accessible for Auditable::Audit model. If model has not attr_accessible, we must patch Auditable::Audit in runtime. Sorry for my bad english
