### PR TITLE
When audits have the same timestamp, only diff against older audits (by ID)

### DIFF
--- a/lib/auditable/base.rb
+++ b/lib/auditable/base.rb
@@ -70,7 +70,7 @@ module Auditable
 
     # Diff this audit with the latest audit created before the `time` variable passed
     def diff_since(time)
-      other_audit = auditable.audits.where("created_at <= ? AND id != ?", time, id).order("id DESC").limit(1).first
+      other_audit = auditable.audits.where("created_at <= ? AND id < ?", time, id).order("id DESC").limit(1).first
 
       diff(other_audit)
     end

--- a/spec/lib/auditable_spec.rb
+++ b/spec/lib/auditable_spec.rb
@@ -42,6 +42,20 @@ describe Auditable do
     end
   end
 
+  it "should only compare older audits when there are multiple audits for a timestamp" do
+    require 'timecop'
+    Timecop.freeze do
+      user.update_attributes :name => "Alpha"
+      user.update_attributes :name => "Bravo"
+      user.update_attributes :name => "Charlie"
+    end
+
+    user.audits[0].latest_diff.should == {"name" => [nil, "test user"]}
+    user.audits[1].latest_diff.should == {"name" => ["test user", "Alpha"]}
+    user.audits[2].latest_diff.should == {"name" => ["Alpha", "Bravo"]}
+    user.audits[3].latest_diff.should == {"name" => ["Bravo", "Charlie"]}
+  end
+
   context "for existing records without existing audits" do
     before do
       survey.audits.delete_all


### PR DESCRIPTION
We've run into an issue where the diffs aren't appearing correctly when there are multiple audits with the same timestamp.  

Because the condition currently checks `created_at <= ? AND id != ?`, it may compare the current audit with a newer one if the timestamps are equal, instead of comparing it with the previous audit as we're expecting.  I've added a test case for this scenario which hopefully explains the expected behavior more clearly than I can describe here.  By changing the condition to `created_at <= ? AND id < ?` we ensure that we're only comparing the current audit against an older state.
